### PR TITLE
2 updates

### DIFF
--- a/etc/acpi/acer-tm-brightdown.sh
+++ b/etc/acpi/acer-tm-brightdown.sh
@@ -2,7 +2,7 @@
 
 max=$(cat /sys/class/backlight/intel_backlight/max_brightness)
 curr=$(cat /sys/class/backlight/intel_backlight/actual_brightness)
-div=$((max / 10))
+div=$((max / 300 + curr / 5))
 next=$((curr-div))
 if [ $next -gt 0 ]; 
 then

--- a/etc/acpi/acer-tm-brightup.sh
+++ b/etc/acpi/acer-tm-brightup.sh
@@ -2,7 +2,7 @@
 
 max=$(cat /sys/class/backlight/intel_backlight/max_brightness)
 curr=$(cat /sys/class/backlight/intel_backlight/actual_brightness)
-div=$((max / 10))
+div=$((max / 300 + curr / 5))
 next=$((curr+div))
 if [ $next -lt $max ]; 
 then

--- a/etc/acpi/events/acer-tm-brightness-down
+++ b/etc/acpi/events/acer-tm-brightness-down
@@ -1,2 +1,2 @@
-event=video DD02 00000087 00000000
+event=video/brightnessdown BRTDN 00000087 00000000
 action=/etc/acpi/acer-tm-brightdown.sh

--- a/etc/acpi/events/acer-tm-brightness-up
+++ b/etc/acpi/events/acer-tm-brightness-up
@@ -1,2 +1,2 @@
-event=video DD02 00000086 00000000
+event=video/brightnessup BRTUP 00000086 00000000
 action=/etc/acpi/acer-tm-brightup.sh


### PR DESCRIPTION
* update ACPI events
* Use smarter diff calculation (gives 19 levels for max_brightness=3125)

Wanted to give this back, since I found your scripts useful in getting this to work on my Acer TravelMate B115-M (one of the few machines that ship without Windows)